### PR TITLE
Allow building the project using a Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/microwave

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+microwave: microwave_example.cpp
+	g++ $< -o $@ -lpistache -lcrypto -lssl -lpthread

--- a/README.md
+++ b/README.md
@@ -2,17 +2,23 @@
 
 ## Getting Started
 
-Git clone this project in your machine. 
+Git clone this project in your machine.
 
 ### Prerequisites
 
-Build tested on Ubuntu Server 
+Build tested on Ubuntu Server
 You will need to have a C++ compiler. I used g++ that came preinstalled. Check using `g++ -v`
 
-You will need to download, and build [Pistache](https://github.com/pistacheio/pistache) library. 
+You will need to install the [Pistache](https://github.com/pistacheio/pistache) library.
+On Ubuntu, you can install a pre-built binary as described [here](http://pistache.io/docs/#installing-pistache).
 
+### Building
 
-### Installing
+#### Using Make
+
+You can build the `microwave` executable by running `make`.
+
+### Manually
 
 A step by step series of examples that tell you how to get a development env running
 
@@ -20,12 +26,14 @@ You should open the terminal, navigate into the root folder of this repository, 
 `g++ microwave_example.cpp -o microwave -lpistache -lcrypto -lssl -lpthread`
 
 This will compile the project using g++, into an executable called `microwave` using the libraries `pistache`, `crypto`, `ssl`, `pthread`. You only really want pistache, but the last three are dependencies of the former.
-Note that in this compilation process, the order of the libraries is important. 
+Note that in this compilation process, the order of the libraries is important.
+
+### Running
 
 To start the server run\
-`./microwave` 
+`./microwave`
 
-Your server should display the number of cores being used and no errors. 
+Your server should display the number of cores being used and no errors.
 
 To test, open up another terminal, and type\
 `curl http://localhost:9080/ready`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Git clone this project in your machine.
 
 ### Prerequisites
 
-Build tested on Ubuntu Server
+Build tested on Ubuntu Server. Pistache doesn't support Windows, but you can use something like [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) or a virtual machine with Linux.
+
 You will need to have a C++ compiler. I used g++ that came preinstalled. Check using `g++ -v`
 
 You will need to install the [Pistache](https://github.com/pistacheio/pistache) library.


### PR DESCRIPTION
A few small changes to simplify building the project:

- provides instructions for building on Windows (need to use WSL or a VM)
- adds links to the installation instructions for pre-built Pistache binaries
- adds a Makefile to allow building the project more easily